### PR TITLE
SE-3436 fix static asset build

### DIFF
--- a/annoto/annoto.py
+++ b/annoto/annoto.py
@@ -14,7 +14,6 @@ from xblock.fields import Scope, String, Boolean
 from xblock.fragment import Fragment
 from xblockutils.studio_editable import StudioEditableXBlockMixin
 from openedx.core.djangoapps.content.course_overviews.models import CourseOverview
-from openedx.core.djangoapps.course_groups.cohorts import get_cohort
 from openedx.core.lib.courses import course_image_url
 from student.roles import CourseInstructorRole, CourseStaffRole, GlobalStaff
 
@@ -159,6 +158,9 @@ class AnnotoXBlock(StudioEditableXBlockMixin, XBlock):
         return fragment
 
     def _base_view(self, context=None):
+        # This must be imported within this function, otherwise the build breaks.
+        from openedx.core.djangoapps.course_groups.cohorts import get_cohort
+
         annoto_auth = self.get_annoto_settings()
         horizontal, vertical = self.get_position()
         translator = self.runtime.service(self, 'i18n').translator


### PR DESCRIPTION
`paver update_assets` doesn't like the global get_cohort import.
I have no idea why.  ¯\\\_(ツ)\_/¯

This change fixes building AMIs when this xblock is included.

**Test instructions**:

- build an ami with the annoto xblock pinned to this revision and verify that it builds successfully
- test using this block.

**Reviewer**:

- [x] @kelketek