### PR TITLE
[SE-4575] merge annoto master

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ https://docs.annoto.net/setup/openedx/widget-integration-xblock
 **Information about Annoto disscusion widget and Insights dashboard:**
 https://docs.annoto.net/guides/
 
-**Information Annoto API:**
+**Information about Annoto API:**
 https://docs.annoto.net/developers/
 
 ## Installation

--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
 # xblock-in-video-collaboration
 Annoto is an in-video collaboration solution that turns static, 1-way video Stream/VOD into an active and interactive group experience, where participants contribute, share and learn together.  Users can lean forward and become participants and not just passive and lonely viewers, causing all users to be actively involved and return to the video content, sharing more ideas and creating more meaningful content. Resulting in higher engagement and retention, supported by comprehensive analytics and insights, that facilitate dramatic improvements to content, communications, and measurable outcomes.
 
-# Visit our online documention
-**Information about the xBlock:**
+# Visit our online documentation
+**Information about the XBlock:**
 https://docs.annoto.net/setup/openedx/widget-integration-xblock
 
-**Information about Annoto disscusion widget and Insights dashboard:**
+**Information about Annoto discussion widget and Insights dashboard:**
 https://docs.annoto.net/guides/
 
 **Information about Annoto API:**

--- a/README.md
+++ b/README.md
@@ -1,6 +1,16 @@
 # xblock-in-video-collaboration
 Annoto is an in-video collaboration solution that turns static, 1-way video Stream/VOD into an active and interactive group experience, where participants contribute, share and learn together.  Users can lean forward and become participants and not just passive and lonely viewers, causing all users to be actively involved and return to the video content, sharing more ideas and creating more meaningful content. Resulting in higher engagement and retention, supported by comprehensive analytics and insights, that facilitate dramatic improvements to content, communications, and measurable outcomes.
 
+# Visit our online documention
+**information about the xBlock:**
+https://docs.annoto.net/setup/openedx/widget-integration-xblock
+
+**information about Annoto disscusion widget and Insights dashboard:**
+https://docs.annoto.net/guides/
+
+**Information Annoto API:**
+https://docs.annoto.net/developers/
+
 ## Installation
 
 ```shell

--- a/README.md
+++ b/README.md
@@ -2,10 +2,10 @@
 Annoto is an in-video collaboration solution that turns static, 1-way video Stream/VOD into an active and interactive group experience, where participants contribute, share and learn together.  Users can lean forward and become participants and not just passive and lonely viewers, causing all users to be actively involved and return to the video content, sharing more ideas and creating more meaningful content. Resulting in higher engagement and retention, supported by comprehensive analytics and insights, that facilitate dramatic improvements to content, communications, and measurable outcomes.
 
 # Visit our online documention
-**information about the xBlock:**
+**Information about the xBlock:**
 https://docs.annoto.net/setup/openedx/widget-integration-xblock
 
-**information about Annoto disscusion widget and Insights dashboard:**
+**Information about Annoto disscusion widget and Insights dashboard:**
 https://docs.annoto.net/guides/
 
 **Information Annoto API:**

--- a/annoto/annoto.py
+++ b/annoto/annoto.py
@@ -90,9 +90,20 @@ class AnnotoXBlock(StudioEditableXBlockMixin, XBlock):
         default="ondemand",
     )
 
+    features = String(
+        display_name=_("Features"),
+        values=(
+            {'display_name': _('Comments & Notes'), 'value': 'comments_notes'},
+            {'display_name': _('Comments'), 'value': 'comments'},
+            {'display_name': _('Private Notes'), 'value': 'notes'},
+            {'display_name': _('Only Analytics'), 'value': 'only_analytics'},
+        ),
+        default="comments_and_notes",
+    )
+
     editable_fields = (
         'display_name', 'widget_position', 'overlay_video', 'tabs',
-        'initial_state', 'discussions_scope', 'video_type'
+        'initial_state', 'discussions_scope', 'video_type', 'features',
     )
 
     has_author_view = True
@@ -199,6 +210,8 @@ class AnnotoXBlock(StudioEditableXBlockMixin, XBlock):
             'courseImage': course_image_url(course),
             'demoMode': not bool(annoto_auth.get('client_id')),
             'isLive': self.video_type == 'stream',
+            'comments': 'comments' in self.features,
+            'privateNotes': 'notes' in self.features,
         }
 
         context['error'] = {}

--- a/annoto/annoto.py
+++ b/annoto/annoto.py
@@ -319,4 +319,4 @@ class AnnotoXBlock(StudioEditableXBlockMixin, XBlock):
         }
 
         token = jwt.encode(payload, annoto_auth['client_secret'], algorithm='HS256')
-        return self._json_resp({'status': 'ok', 'token': str(token)})
+        return self._json_resp({'status': 'ok', 'token': token})

--- a/annoto/annoto.py
+++ b/annoto/annoto.py
@@ -93,7 +93,7 @@ class AnnotoXBlock(StudioEditableXBlockMixin, XBlock):
     features = String(
         display_name=_("Features"),
         values=(
-            {'display_name': _('Comments & Notes'), 'value': 'comments_notes'},
+            {'display_name': _('Comments & Notes'), 'value': 'comments_and_notes'},
             {'display_name': _('Comments'), 'value': 'comments'},
             {'display_name': _('Private Notes'), 'value': 'notes'},
             {'display_name': _('Only Analytics'), 'value': 'only_analytics'},
@@ -140,7 +140,7 @@ class AnnotoXBlock(StudioEditableXBlockMixin, XBlock):
         context = context or {}
         context['is_author_view'] = False
         frag = self._base_view(context=context)
-        frag.add_javascript_url('//app.annoto.net/annoto-bootstrap.js');
+        frag.add_javascript_url('//app.annoto.net/annoto-bootstrap.js')
         return frag
 
     def studio_view(self, context):

--- a/annoto/annoto.py
+++ b/annoto/annoto.py
@@ -15,7 +15,6 @@ from xblock.fragment import Fragment
 from xblockutils.studio_editable import StudioEditableXBlockMixin
 from openedx.core.djangoapps.user_api.accounts.image_helpers import get_profile_image_urls_for_user
 from openedx.core.djangoapps.content.course_overviews.models import CourseOverview
-from openedx.core.djangoapps.course_groups.cohorts import get_cohort
 from openedx.core.lib.courses import course_image_url
 from student.roles import CourseInstructorRole, CourseStaffRole, GlobalStaff
 
@@ -187,7 +186,8 @@ class AnnotoXBlock(StudioEditableXBlockMixin, XBlock):
         course_id = str(self.course_id)
         course_display_name = course.display_name
         user = self._get_user()
-        if user and self.discussions_scope == 'cohort':
+        if not context['is_author_view'] and user and self.discussions_scope == 'cohort':
+            from openedx.core.djangoapps.course_groups.cohorts import get_cohort
             cohort = get_cohort(user, self.course_id)
             if cohort:
                 course_id = u'{}_{}'.format(course_id, cohort.id)

--- a/annoto/annoto.py
+++ b/annoto/annoto.py
@@ -319,4 +319,4 @@ class AnnotoXBlock(StudioEditableXBlockMixin, XBlock):
         }
 
         token = jwt.encode(payload, annoto_auth['client_secret'], algorithm='HS256')
-        return self._json_resp({'status': 'ok', 'token': token})
+        return self._json_resp({'status': 'ok', 'token': str(token)})

--- a/annoto/static/js/src/annoto.js
+++ b/annoto/static/js/src/annoto.js
@@ -50,6 +50,8 @@ function AnnotoXBlock(runtime, element, options) {
                     relativePositionElement: videoWrapper,
                     features: {
                         tabs: enableTabs,
+                        comments: options.comments,
+                        privateNotes: options.privateNotes
                     },
                     locale: options.language,
                     rtl: options.rtl,

--- a/annoto/static/js/src/annoto.js
+++ b/annoto/static/js/src/annoto.js
@@ -51,7 +51,8 @@ function AnnotoXBlock(runtime, element, options) {
                     features: {
                         tabs: enableTabs,
                         comments: options.comments,
-                        privateNotes: options.privateNotes
+                        privateNotes: options.privateNotes,
+                        timeline: options.comments || options.privateNotes
                     },
                     locale: options.language,
                     rtl: options.rtl,

--- a/annoto/static/js/src/annoto.js
+++ b/annoto/static/js/src/annoto.js
@@ -107,7 +107,7 @@ function AnnotoXBlock(runtime, element, options) {
                 Annoto.boot(config);
             };
 
-            $('.xmodule_VideoModule .video').first().on('ready', setupAnnoto);
+            $('.xmodule_VideoBlock .video, .xmodule_VideoModule .video').first().on('ready', setupAnnoto);
         });
     };
 

--- a/annoto/tests.py
+++ b/annoto/tests.py
@@ -33,6 +33,7 @@ class AnnotoXBlockTests(unittest.TestCase):
         self.assertEqual(block.tabs, 'enabled')
         self.assertEqual(block.initial_state, 'auto')
         self.assertTrue(block.discussions_scope)
+        self.assertEqual(block.features, 'comments_notes')
 
     def test_set_fields_custom_values(self):
         block = self.make_one()
@@ -43,7 +44,8 @@ class AnnotoXBlockTests(unittest.TestCase):
             'overlay_video': False,
             'tabs': 'hidden',
             'initial_state': 'open',
-            'discussions_scope': False
+            'discussions_scope': False,
+            'features': 'only_analytics',
         }
 
         block.submit_studio_edits(mock.Mock(method="POST",
@@ -55,6 +57,7 @@ class AnnotoXBlockTests(unittest.TestCase):
         self.assertEqual(block.tabs, 'hidden')
         self.assertEqual(block.initial_state, 'open')
         self.assertFalse(block.discussions_scope)
+        self.assertEqual(block.features, 'only_analytics')
 
     def test_position_parser(self):
         block = self.make_one()

--- a/annoto/tests.py
+++ b/annoto/tests.py
@@ -1,8 +1,9 @@
 import jwt
 import mock
 import json
+import time
 import unittest
-from ddt import ddt
+from ddt import ddt, data
 
 from xblock.field_data import DictFieldData
 
@@ -25,17 +26,19 @@ class AnnotoXBlockTests(unittest.TestCase):
         )
         return block
 
-    def test_default_filelds_values(self):
+    def test_default_fields_values(self):
         block = self.make_one()
         self.assertEqual(block.display_name, 'Annoto')
-        self.assertEqual(block.widget_position, 'top-left')
+        self.assertEqual(block.widget_position, 'left-top')
         self.assertTrue(block.overlay_video)
         self.assertEqual(block.tabs, 'enabled')
         self.assertEqual(block.initial_state, 'auto')
-        self.assertTrue(block.discussions_scope)
-        self.assertEqual(block.features, 'comments_notes')
+        self.assertEqual(block.discussions_scope, 'cohort')
+        self.assertEqual(block.features, 'comments_and_notes')
 
-    def test_set_fields_custom_values(self):
+    # Tthis change does not make sense, because the StudioEditableXBlockMixin code has already been tested
+    @data('comments', 'notes', 'only_analytics')
+    def test_set_fields_custom_values(self, features_value):
         block = self.make_one()
 
         fields = {
@@ -44,24 +47,27 @@ class AnnotoXBlockTests(unittest.TestCase):
             'overlay_video': False,
             'tabs': 'hidden',
             'initial_state': 'open',
-            'discussions_scope': False,
-            'features': 'only_analytics',
+            'discussions_scope': 'course',
+            'features': features_value,
         }
 
-        block.submit_studio_edits(mock.Mock(method="POST",
-            body=json.dumps({'values': fields, 'defaults': [block.editable_fields]})))
+        block.submit_studio_edits(
+            mock.Mock(
+                method="POST", body=json.dumps({'values': fields, 'defaults': [block.editable_fields]})
+            )
+        )
 
         self.assertEqual(block.display_name, 'Test Annoto')
         self.assertEqual(block.widget_position, 'bottom-left')
         self.assertFalse(block.overlay_video)
         self.assertEqual(block.tabs, 'hidden')
         self.assertEqual(block.initial_state, 'open')
-        self.assertFalse(block.discussions_scope)
-        self.assertEqual(block.features, 'only_analytics')
+        self.assertEqual(block.discussions_scope, 'course')
+        self.assertEqual(block.features, features_value)
 
     def test_position_parser(self):
         block = self.make_one()
-        self.assertEqual(block.get_position(), (u'right', u'top'))
+        self.assertEqual(block.get_position(), [u'left', u'top'])
 
     @mock.patch('annoto.AnnotoXBlock.get_course_obj')
     def test_get_annoto_settings(self, get_course_obj_mock):
@@ -82,38 +88,53 @@ class AnnotoXBlockTests(unittest.TestCase):
 
     @mock.patch('annoto.annoto.time')
     @mock.patch('annoto.AnnotoXBlock.get_course_obj')
+    @mock.patch('annoto.AnnotoXBlock._get_user')
     @mock.patch('annoto.AnnotoXBlock._build_absolute_uri')
     @mock.patch('annoto.annoto.get_profile_image_urls_for_user')
-    def test_get_jwt_token(self, get_profile_image_urls_for_user_mock,
-                           build_absolute_uri_mock, get_course_obj_mock, time_mock):
+    def test_get_jwt_token(self, get_profile_image_urls_for_user_mock, build_absolute_uri_mock,
+                           _get_user_mock, get_course_obj_mock, time_mock):
         client_id = 'test_id'
         lti_passports = ['annoto-auth:{}:test_secret'.format(client_id)]
 
         expect_payload = {
-            u'expire': 1234567,
+            u'exp': int(time.time()) + 60 * 20,
             u'iss': u'test_id',
             u'jti': u'test_user_id',
             u'name': u'test_user_name',
+            u'scope': u'user',
             u'email': u'test_user_email',
-            u'photoUrl': u'test_user_photo_url'
+            u'photoUrl': u'test_user_photo_url',
         }
+
+        courseaccessrole_set = mock.Mock(
+            filter=mock.Mock(
+                return_value=mock.Mock(
+                    values_list=mock.Mock(
+                        return_value=[]
+                    )
+                )
+            )
+        )
 
         profile_mock = mock.Mock()
         profile_mock.configure_mock(name=expect_payload['name'])
 
         user_mock = mock.Mock(
             email=expect_payload['email'],
-            profile=profile_mock
+            profile=profile_mock,
+            is_staff=False,
+            courseaccessrole_set=courseaccessrole_set,
         )
         user_mock.configure_mock(id=expect_payload['jti'])
 
         block = self.make_one()
+        block.course_id = None
 
-        block.runtime = mock.Mock(service=mock.Mock(return_value=mock.Mock(_django_user=user_mock)))
+        _get_user_mock.return_value = user_mock
         get_course_obj_mock.return_value = mock.Mock(lti_passports=lti_passports)
         get_profile_image_urls_for_user_mock.return_value = {'small': 'empty'}
         build_absolute_uri_mock.return_value = expect_payload['photoUrl']
-        time_mock.configure_mock(time=mock.Mock(return_value=expect_payload['expire'] - 60 * 20))
+        time_mock.configure_mock(time=mock.Mock(return_value=expect_payload['exp'] - 60 * 20))
 
         auth = block.get_annoto_settings()
 


### PR DESCRIPTION
Pull `annoto/xblock-in-video-collaboration` upstream master changes.

**Dependencies**: None

**Sandbox URL**: TBD - sandbox is being provisioned.

**Merge deadline**: None

**Testing instructions**:

* Check annoto [xblock is added](https://studio.stage.campus.gov.il/container/block-v1:OpenCraft+CS101+2021_T1+type@vertical+block@c3e360f864db472da0bf071835d728d5)
* Check the [page loads fine](https://preview.stage.campus.gov.il/courses/course-v1:OpenCraft+CS101+2021_T1/courseware/21efd00c618c4ecaa2666be3e445778f/1d8df78bc3eb424a9864135c978a1159/1?activate_block_id=block-v1%3AOpenCraft%2BCS101%2B2021_T1%2Btype%40vertical%2Bblock%40c3e360f864db472da0bf071835d728d5) -- annoto xblock should produce no content

**Author notes and concerns**:

N/A

**Reviewers**
- [ ] @jvdm